### PR TITLE
Pass in runtime handler for blocking calls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ url = "2.2.2"
 rustls = { version = "0.20", optional = true }
 rustls-native-certs = { version = "0.6", optional = true }
 http = { version = "0.2.4", optional = true }
-tokio = { version = "1.15.0", features = ["io-util", "macros", "net", "rt", "rt-multi-thread", "sync", "time"] }
+tokio = { version = "1", features = ["io-util", "macros", "net", "rt", "rt-multi-thread", "sync", "time"] }
 tokio-rustls = { version = "0.23", optional = true }
 tokio-tungstenite = { version = "0.16", optional = true, features = ["rustls-tls-native-roots"] }
 

--- a/src/client/client.rs
+++ b/src/client/client.rs
@@ -430,14 +430,14 @@ impl Client {
     /// Attempt to fetch the next Publish packet for one of this Client's
     /// subscriptions but return immediately. Syncronous version of
     /// `read_subscriptions()`.
+    ///
+    /// TODO: Figure out why `try_recv()` and `try_poll()` are so cpu intensive
+    /// (makes hootl binary running two vehicles go from 50% cpu usage to >200%).
+    /// Seems as though they possibly are only meant to be used to check if there
+    /// are messages on the receiver, rather than being the primary way to extract
+    /// messages from the receiver.
+    /// Until then, this function is too cpu intentsive to use
     pub fn try_read_subscriptions(&mut self) -> Option<Result<ReadResult>> {
-        // TODO: Figure out why try_recv() and try_poll() are so cpu intensive
-        // (makes hootl binary running two vehicles go from 50% cpu usage to >200%).
-        // Seems as though they possibly are only meant to be used to check if there
-        // are messages on the receiver, rather than being the primary way to extract
-        // messages from the receiver.
-        // Until then, this function is too cpu intentsive to use
-
         match self.check_io_task_mut() {
             Ok(h) => match h.rx_recv_published.try_recv() {
                 Ok(r) => match r {


### PR DESCRIPTION
# Background

The blocking `try_read_subscriptions` will fail if called from functions that have their own runtime (which is often the case). This is because the channels send_blocking call under the hood uses a block_on function, causing the runtime within runtime error.

# Description

Instead, this commit requires passing in a handler to these functions so rather than blocking on the channel send (which is purely used for sending mqtt ACKs), it will queue the send on an async thread so it is completed in the background. This is better overall so we are not waiting on any network or IPC calls at all for these functions to return, resulting in more predictable behavior.

# Verification

Works predictably with local referencing of this crate in server-utils when using `try_read_subscriptions`
